### PR TITLE
Fixed the meta title -- previously had default template text so that …

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="A front-end template that helps you build fast, modern mobile web apps.">
+    <meta name="description" content="The Michigan Student Artificial Intelligence Lab">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>MSAIL - Michigan Student Artificial Intelligence Lab</title>
 


### PR DESCRIPTION
…links on facebook would read 'A front end template ...'
